### PR TITLE
Add types for Arbo-based StateDB storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ CLIENT_STORE_SOURCES=$(wildcard src/client-store/*.proto)
 METADATA_SOURCES=$(wildcard src/metadata/*.proto)
 VOCHAIN_SOURCES=$(wildcard src/vochain/*.proto)
 IPFSSYNC_SOURCES=$(wildcard src/ipfsSync/*.proto)
+VOCDONI_NODE_SOURCES=$(wildcard src/vocdoni-node/*.proto)
 
 PROTOC?=$(shell which protoc)
 $(if $(PROTOC),,$(eval PROTOC=bin/protoc))
@@ -76,7 +77,7 @@ all: protoc build/dart build/ts build/go/models
 ## golang: Generate the Golang protobuf artifacts
 golang: protoc protoc-go-plugin build/go/models
 
-build/go/models: $(VOCHAIN_SOURCES) $(IPFSSYNC_SOURCES)
+build/go/models: $(VOCHAIN_SOURCES) $(VOCDONI_NODE_SOURCES) $(IPFSSYNC_SOURCES)
 	rm -rf $@
 	mkdir -p $@
 	for f in $^ ; do \

--- a/src/vocdoni-node/statedb.proto
+++ b/src/vocdoni-node/statedb.proto
@@ -1,0 +1,25 @@
+syntax = "proto3";
+
+package dvote.types.v1;
+
+import "vochain/vochain.proto";
+
+option go_package = "go.vocdoni.io/proto/build/go/models";
+
+// Process as it is stored in the Arbo-based StateDB
+message StateDBProcess {
+    // vochain Process
+    Process process = 1;
+    // root of the StateDB SubTree that contains the proces' votes
+    bytes votesRoot = 2;
+}
+
+// Vote as it is stored in the Arbo-based StateDB
+message StateDBVote {
+    // hash of the protobuf-marshalled Vote
+    bytes voteHash = 1;
+    // processId from Vote.processId
+    bytes processId = 2;
+    // nullifier from Vote.nullifier
+    bytes nullifier = 3;
+}


### PR DESCRIPTION
The new Arbo-based StateDB has a different layout and requires storing some extra information that is not available in the vochain types.  I've created a new folder for types used only inside the vocdoni-node.  In particular I was looking for a way to serialize and deserialize types to bytes for persistent storage in the StateDB, and I think using protobuf is what makes more sense.