### PR TITLE
vochain: consistency changes & future proof types

### DIFF
--- a/src/vochain/vochain.proto
+++ b/src/vochain/vochain.proto
@@ -291,7 +291,7 @@ message SetKeykeeperTx {
 
 message Process {
 	bytes processId = 1;
-	// EntityId identifies unequivocally a process
+	// EntityId identifies unequivocally an entity
 	bytes entityId = 2;
 	// StartBlock represents the tendermint block where the process goes from scheduled to active
 	uint32 startBlock = 3;

--- a/src/vochain/vochain.proto
+++ b/src/vochain/vochain.proto
@@ -162,6 +162,8 @@ enum TxType {
 	ADD_DELEGATE_FOR_ACCOUNT = 18;
 	DEL_DELEGATE_FOR_ACCOUNT = 19;
 	COLLECT_FAUCET = 20;
+	ADD_KEYKEEPER = 21;
+	DELETE_KEYKEEPER = 22;
 }
 
 message Tx {
@@ -177,6 +179,7 @@ message Tx {
 		SetAccountInfoTx setAccountInfo = 9;
 		SetAccountDelegateTx setAccountDelegateTx = 10;
 		CollectFaucetTx collectFaucet = 11;
+		SetKeykeeperTx setKeykeeper = 12;
 	}
 }
 
@@ -280,6 +283,12 @@ message FaucetPackage {
 	bytes signature = 2;
 }
 
+message SetKeykeeperTx {
+	TxType txtype = 1;
+	uint32 nonce = 2;
+	bytes keykeeper = 3;
+}
+
 message Process {
 	bytes processId = 1;
 	// EntityId identifies unequivocally a process
@@ -353,6 +362,7 @@ enum SourceNetworkId {
 	AVAX_FUJI = 10;
 	AVAX = 11;
 	POLYGON_MUMBAI = 12;
+
 }
 
 enum CensusOrigin {

--- a/src/vochain/vochain.proto
+++ b/src/vochain/vochain.proto
@@ -362,7 +362,8 @@ enum SourceNetworkId {
 	AVAX_FUJI = 10;
 	AVAX = 11;
 	POLYGON_MUMBAI = 12;
-
+	OPTIMISM = 13;
+	ARBITRUM = 14;
 }
 
 enum CensusOrigin {

--- a/src/vochain/vochain.proto
+++ b/src/vochain/vochain.proto
@@ -195,13 +195,13 @@ message SignedTx {
 
 message NewProcessTx {
 	TxType txtype = 1;
-	bytes nonce = 2;
+	uint32 nonce = 2;
 	Process process = 3;
 }
 
 message SetProcessTx {
 	TxType txtype = 1;
-	bytes nonce = 2;
+	uint32 nonce = 2;
 	bytes processId = 3;
 	optional ProcessStatus status = 4;
 	optional uint32 questionIndex = 5;
@@ -220,11 +220,11 @@ message AdminTx {
 	optional uint32 keyIndex = 7;
 	optional uint64 power = 8;
 	optional bytes publicKey = 9;
-	bytes nonce = 11;
+	uint32 nonce = 11;
 }
 
 message RegisterKeyTx {
-	bytes nonce = 1;  	  // Unique number per vote attempt, so that replay attacks can't reuse this payload
+	uint32 nonce = 1;  	  // Unique number per vote attempt, so that replay attacks can't reuse this payload
 	bytes processId = 2;  // The process for which the vote is casted
 	Proof proof = 3;  	  // Franchise proof
 	bytes newKey = 4;     // New key to register


### PR DESCRIPTION
- Add support for Arbitrum and Optimism network types
- Unify nonce for certain txs, from bytes to uint32
- Create add/del KeyKeeper txs
- Fix Process message entityId typo