### PR TITLE
proof arbo: add key type parameter

### DIFF
--- a/src/vochain/vochain.proto
+++ b/src/vochain/vochain.proto
@@ -103,9 +103,14 @@ message ProofArbo {
 			BLAKE2B = 0;
 			POSEIDON = 1;
 	}
+	enum KeyType {
+		PUBKEY = 0;
+		ADDRESS = 1;
+	}
 	Type type = 1;
 	bytes siblings = 2;
 	bytes value = 3;
+	KeyType keyType = 4;
 }
 
 // Groth16 zkSNARK proof + public inputs


### PR DESCRIPTION
Allows to use ethereum addresses census. Does not break backwards compatibility.

Signed-off-by: p4u <pau@dabax.net>