### PR TITLE
Fixed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,11 @@
 {
   "devDependencies": {
-    "protobufjs": "^6.10.2",
     "ts-node": "^9.1.1",
     "ts-proto": "^1.131.0",
     "typescript": "^4.2.4"
+  },
+  "dependencies": {
+    "long": "^5.2.1",
+    "protobufjs": "^7.1.2"
   }
 }


### PR DESCRIPTION
Fixed dependencies in `package.json`

Added `protobufjs` and `long` as dependencies instead of dev dependencies as used in `vochain.ts`.

Also upgraded to newer versions of the packages so a complete test is encouraged.