### PR TITLE
Remove ts build step in post-merge action

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -22,7 +22,6 @@ jobs:
           make init
           make dart
           make golang
-          make ts
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v2.3.0
         with:


### PR DESCRIPTION
There's no need to build ts/js files in this action anymore, since that part is handled by the on-release action now.

This is in reference to this comment I added to an auto-build commit: https://github.com/vocdoni/dvote-protobuf/commit/e9395b8603c1c5e6ae8e51ea1c283a8ac030d40a#commitcomment-105548906