### PR TITLE
ci: bump node version v14 -> v18

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "18"
       - uses: actions/setup-go@v3
       - name: Build
         run: |


### PR DESCRIPTION
something failed during the CI of the last commit pushed to `master`
https://github.com/vocdoni/dvote-protobuf/actions/runs/5727804601/attempts/1

after some debugging and local tests (with a recent node+npm) i spotted this in the original run
```
npm WARN notsup Unsupported engine for rollup@3.27.0: wanted: {"node":">=14.18.0","npm":">=8.0.0"} (current: {"node":"14.21.3","npm":"6.14.18"})
```

i.e. npm is waaay too old. a simple bump to node v18 solves the issue, see a clean run (no WARNs) in
https://github.com/vocdoni/dvote-protobuf/actions/runs/5737196458