### PR TITLE
ci: finish npm OIDC trusted publishing; release @vocdoni/proto 1.15.13

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -8,6 +8,10 @@ on:
     tags:
     - '*'
   pull_request: ~
+  workflow_dispatch: ~
+permissions:
+  contents: write
+  id-token: write
 jobs:
   protobuf-build:
     runs-on: ubuntu-latest
@@ -16,8 +20,10 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
+      - name: Update npm (OIDC trusted publishing needs npm >= 11.5.1)
+        run: npm install -g npm@latest
       - uses: actions/setup-go@v3
       - name: Build
         run: |
@@ -41,8 +47,8 @@ jobs:
           fi
 
       - name: Publish to npm
-        if: env.is_tag == 'true'
+        if: env.is_tag == 'true' || github.event_name == 'workflow_dispatch'
         run: |
           yarn
           yarn build
-          yarn publish
+          npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vocdoni/proto",
-  "version": "1.16.0",
+  "version": "1.15.13",
   "license": "GPL-3.0-or-later",
   "devDependencies": {
     "ts-node": "^9.1.1",


### PR DESCRIPTION
## Problem
The `Post merge build step` workflow fails to publish `@vocdoni/proto` (e.g. run [29809567466](https://github.com/vocdoni/dvote-protobuf/actions/runs/29809567466)):
```
[3/4] Publishing...
error Couldn't publish package: "https://registry.npmjs.org/@vocdoni%2fproto: Not found"
```
The trusted-publisher migration in `6efbe10` removed `NODE_AUTH_TOKEN` but left the step on **`yarn publish`**, which cannot perform npm's OIDC trusted publishing. So the publish runs unauthenticated and npm returns `Not found`. The migration was half-done.

## Fix (finish the OIDC migration)
- `yarn publish` → **`npm publish --provenance --access public`** (OIDC-capable).
- Add `permissions: id-token: write` (OIDC) and `contents: write` (the existing git-auto-commit step).
- Bump `setup-node` to Node 22 and `npm install -g npm@latest` — OIDC trusted publishing needs npm ≥ 11.5.1 (which needs Node ≥ 20).
- Add `workflow_dispatch` and let it publish, so master can be released without a tag. Normal `vX.Y.Z` tag publishing is unchanged.

## Version
Sets `package.json` to **1.15.13** to match the Go module tag `v1.15.13` already consumed by vocdoni-node. (npm latest is 1.15.12; 1.15.13/1.16.0 were never published.) The `v1.15.13` git tag is immutable and its commit carries `package.json 1.16.0`, so this release is published from master via `workflow_dispatch` after merge.

## ⚠️ Prerequisite
npm **Trusted Publisher** must be configured for `@vocdoni/proto` → `vocdoni/dvote-protobuf`, workflow `post-merge.yml`. If it isn't set up, OIDC publish will still fail and we'd need to fall back to a token (`NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`).

## Release steps (after merge)
1. Post-merge CI regenerates `build/` (publish skipped on plain master push).
2. Run the workflow: Actions → *Post merge build step* → **Run workflow** on `master` (or `gh workflow run`).
3. Verify `npm view @vocdoni/proto version` → `1.15.13`.

Only `post-merge.yml` + `package.json` changed; CI regenerates `build/` per repo convention.