### PR TITLE
fix(npm): add repository field so provenance publish succeeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@vocdoni/proto",
   "version": "1.15.13",
   "license": "GPL-3.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vocdoni/dvote-protobuf.git"
+  },
   "devDependencies": {
     "ts-node": "^9.1.1",
     "ts-proto": "^1.181.2",


### PR DESCRIPTION
Follow-up to #77. The OIDC trusted publish now authenticates and signs provenance, but npm rejected it:

```
npm error 422 Unprocessable Entity - Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match "https://github.com/vocdoni/dvote-protobuf"
```

`npm publish --provenance` requires `package.json` to declare the source repository. Adds the `repository` field. Nothing was published (npm latest is still 1.15.12).

After merge: re-run *Post merge build step* on `master` (workflow_dispatch) to publish 1.15.13.